### PR TITLE
fix(mcp-media): use predictLongRunning for Veo video generation

### DIFF
--- a/cmd/mcp-media/gemini.go
+++ b/cmd/mcp-media/gemini.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
+	"time"
 )
 
 // GeminiProvider uses the Gemini REST API for image, video, music, and TTS.
@@ -111,26 +113,151 @@ func (g *GeminiProvider) EditImage(ctx context.Context, imagePath, prompt, model
 // --- Video ---
 
 func (g *GeminiProvider) GenerateVideo(ctx context.Context, prompt, model, imagePath string) (*MediaResult, error) {
-	parts := []interface{}{map[string]string{"text": prompt}}
+	instance := map[string]interface{}{"prompt": prompt}
 	if imagePath != "" {
 		imgData, err := os.ReadFile(imagePath)
 		if err != nil {
 			return nil, fmt.Errorf("read image: %w", err)
 		}
-		b64 := base64.StdEncoding.EncodeToString(imgData)
-		parts = append([]interface{}{
-			map[string]interface{}{"inline_data": map[string]string{"mime_type": "image/png", "data": b64}},
-		}, parts...)
+		mime := mimeFromPath(imagePath)
+		instance["image"] = map[string]string{
+			"bytesBase64Encoded": base64.StdEncoding.EncodeToString(imgData),
+			"mimeType":           mime,
+		}
 	}
 	body := map[string]interface{}{
-		"contents": []map[string]interface{}{
-			{"parts": parts},
-		},
-		"generationConfig": map[string]interface{}{
-			"responseModalities": []string{"VIDEO"},
-		},
+		"instances":  []interface{}{instance},
+		"parameters": map[string]interface{}{"aspectRatio": "16:9", "resolution": "720p", "durationSeconds": 8, "sampleCount": 1},
 	}
-	return g.generate(ctx, g.apiModel(model), body)
+
+	apiModel := g.apiModel(model)
+	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:predictLongRunning?key=%s", apiModel, g.apiKey)
+	jsonBody, _ := json.Marshal(body)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("veo submit %d: %s", resp.StatusCode, truncStr(string(respBody), 500))
+	}
+
+	var op struct{ Name string }
+	if err := json.Unmarshal(respBody, &op); err != nil || op.Name == "" {
+		return nil, fmt.Errorf("no operation name: %s", truncStr(string(respBody), 300))
+	}
+
+	return g.pollVideo(ctx, op.Name)
+}
+
+// pollVideo polls a predictLongRunning operation until completion and returns the video.
+func (g *GeminiProvider) pollVideo(ctx context.Context, opName string) (*MediaResult, error) {
+	pollURL := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/%s?key=%s", opName, g.apiKey)
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for i := 0; i < 120; i++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+
+		pr, err := http.NewRequestWithContext(ctx, "GET", pollURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		pResp, err := g.client.Do(pr)
+		if err != nil {
+			return nil, err
+		}
+		pBody, _ := io.ReadAll(pResp.Body)
+		pResp.Body.Close()
+		if pResp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("veo poll %d: %s", pResp.StatusCode, truncStr(string(pBody), 500))
+		}
+
+		var status struct {
+			Done  bool                    `json:"done"`
+			Error *struct{ Message string } `json:"error"`
+		}
+		if err := json.Unmarshal(pBody, &status); err != nil {
+			continue
+		}
+		if !status.Done {
+			continue
+		}
+		if status.Error != nil {
+			return nil, fmt.Errorf("veo error: %s", status.Error.Message)
+		}
+
+		return g.parseVideoResponse(ctx, pBody)
+	}
+	return nil, fmt.Errorf("veo timeout after 10 minutes")
+}
+
+// parseVideoResponse extracts the video URI from a completed operation response.
+func (g *GeminiProvider) parseVideoResponse(ctx context.Context, body []byte) (*MediaResult, error) {
+	var op struct {
+		Response struct {
+			GenerateVideoResponse struct {
+				Samples []struct {
+					Video struct {
+						URI string `json:"uri"`
+					} `json:"video"`
+				} `json:"generatedSamples"`
+			} `json:"generateVideoResponse"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(body, &op); err != nil {
+		return nil, fmt.Errorf("parse video response: %w", err)
+	}
+	for _, s := range op.Response.GenerateVideoResponse.Samples {
+		if s.Video.URI != "" {
+			path, err := g.downloadVideo(ctx, s.Video.URI)
+			if err != nil {
+				return nil, err
+			}
+			return &MediaResult{Path: path, MimeType: "video/mp4"}, nil
+		}
+	}
+	return nil, fmt.Errorf("veo done but no video URI in response: %s", truncStr(string(body), 500))
+}
+
+func (g *GeminiProvider) downloadVideo(ctx context.Context, uri string) (string, error) {
+	dlURL := uri
+	if !strings.Contains(dlURL, "key=") {
+		sep := "?"
+		if strings.Contains(dlURL, "?") {
+			sep = "&"
+		}
+		dlURL += sep + "key=" + g.apiKey
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET", dlURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("download video %d: %s", resp.StatusCode, truncStr(string(body), 300))
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return saveBytes(data, "mp4")
 }
 
 // --- Music ---
@@ -231,6 +358,18 @@ type geminiResponse struct {
 			} `json:"parts"`
 		} `json:"content"`
 	} `json:"candidates"`
+}
+
+func mimeFromPath(path string) string {
+	lower := strings.ToLower(path)
+	switch {
+	case strings.HasSuffix(lower, ".jpg"), strings.HasSuffix(lower, ".jpeg"):
+		return "image/jpeg"
+	case strings.HasSuffix(lower, ".webp"):
+		return "image/webp"
+	default:
+		return "image/png"
+	}
 }
 
 func truncStr(s string, n int) string {


### PR DESCRIPTION
## Summary

Veo video generation was returning 404 because it used the `generateContent` endpoint, which doesn't support Veo models. Veo requires the async `predictLongRunning` endpoint with a different request format.

## Changes

- **Endpoint**: `generateContent` → `predictLongRunning` (async submit + poll)
- **Request body**: Gemini `contents/parts/inline_data` → Vertex AI `instances/parameters/bytesBase64Encoded`
- **Polling**: ticker + `ctx.Done` select for proper context cancellation
- **Response parsing**: single typed struct instead of 3x `json.RawMessage` with swallowed errors
- **MIME detection**: extracted `mimeFromPath()` helper (jpg/jpeg/webp/png)
- **Structure**: split into `pollVideo()` + `parseVideoResponse()` for clarity

## Tested

- `go build` ✅
- `go vet` ✅
- Text-only video generation → valid MP4 ✅
- Image-to-video generation → valid MP4 ✅