### PR TITLE
fix(mcp-media): handle ignored error returns in gemini and openai providers

### DIFF
--- a/cmd/mcp-media/gemini.go
+++ b/cmd/mcp-media/gemini.go
@@ -132,7 +132,10 @@ func (g *GeminiProvider) GenerateVideo(ctx context.Context, prompt, model, image
 
 	apiModel := g.apiModel(model)
 	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:predictLongRunning?key=%s", apiModel, g.apiKey)
-	jsonBody, _ := json.Marshal(body)
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
 	if err != nil {
 		return nil, err
@@ -144,7 +147,10 @@ func (g *GeminiProvider) GenerateVideo(ctx context.Context, prompt, model, image
 		return nil, err
 	}
 	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read veo response: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("veo submit %d: %s", resp.StatusCode, truncStr(string(respBody), 500))
 	}
@@ -178,8 +184,11 @@ func (g *GeminiProvider) pollVideo(ctx context.Context, opName string) (*MediaRe
 		if err != nil {
 			return nil, err
 		}
-		pBody, _ := io.ReadAll(pResp.Body)
+		pBody, err := io.ReadAll(pResp.Body)
 		pResp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read poll response: %w", err)
+		}
 		if pResp.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("veo poll %d: %s", pResp.StatusCode, truncStr(string(pBody), 500))
 		}
@@ -250,7 +259,7 @@ func (g *GeminiProvider) downloadVideo(ctx context.Context, uri string) (string,
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body) // best-effort for error message
 		return "", fmt.Errorf("download video %d: %s", resp.StatusCode, truncStr(string(body), 300))
 	}
 	data, err := io.ReadAll(resp.Body)
@@ -302,7 +311,10 @@ func (g *GeminiProvider) TextToSpeech(ctx context.Context, text, model, voice st
 
 func (g *GeminiProvider) generate(ctx context.Context, model string, body map[string]interface{}) (*MediaResult, error) {
 	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s", model, g.apiKey)
-	jsonBody, _ := json.Marshal(body)
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
 	if err != nil {
 		return nil, err
@@ -314,7 +326,10 @@ func (g *GeminiProvider) generate(ctx context.Context, model string, body map[st
 		return nil, err
 	}
 	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("gemini %d: %s", resp.StatusCode, truncStr(string(respBody), 500))
 	}

--- a/cmd/mcp-media/openai.go
+++ b/cmd/mcp-media/openai.go
@@ -53,7 +53,10 @@ func (o *OpenAIProvider) GenerateImage(ctx context.Context, prompt, model, size,
 		"n":      1,
 		"size":   size,
 	}
-	jsonBody, _ := json.Marshal(body)
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
 	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.openai.com/v1/images/generations", bytes.NewReader(jsonBody))
 	if err != nil {
 		return nil, err
@@ -66,7 +69,10 @@ func (o *OpenAIProvider) GenerateImage(ctx context.Context, prompt, model, size,
 		return nil, err
 	}
 	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("openai %d: %s", resp.StatusCode, truncStr(string(respBody), 500))
 	}
@@ -116,7 +122,10 @@ func (o *OpenAIProvider) TextToSpeech(ctx context.Context, text, model, voice st
 		"input": text,
 		"voice": voice,
 	}
-	jsonBody, _ := json.Marshal(body)
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
 	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.openai.com/v1/audio/speech", bytes.NewReader(jsonBody))
 	if err != nil {
 		return nil, err
@@ -130,7 +139,7 @@ func (o *OpenAIProvider) TextToSpeech(ctx context.Context, text, model, voice st
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(resp.Body) // best-effort for error message
 		return nil, fmt.Errorf("openai tts %d: %s", resp.StatusCode, truncStr(string(respBody), 500))
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to PR #16. Fixes ignored Go error returns in `cmd/mcp-media/` to comply with project rule: **err 必須處理或顯式 `_ =` 標註理由**.

## Changes

**gemini.go:**
- `json.Marshal` → proper error return (in `GenerateVideo` and `generate`)
- `io.ReadAll` → proper error return (in `GenerateVideo`, `pollVideo`, `generate`)
- Error-path `io.ReadAll` in `downloadVideo` → added `// best-effort for error message` comment

**openai.go:**
- `json.Marshal` → proper error return (in `GenerateImage` and `TextToSpeech`)
- `io.ReadAll` → proper error return (in `GenerateImage`)
- Error-path `io.ReadAll` in `TextToSpeech` → added `// best-effort for error message` comment

## Verified

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅